### PR TITLE
Add convenience methods to present BottomSheet. Take out appearance parameters to configuration

### DIFF
--- a/BottomSheetDemo.xcodeproj/project.pbxproj
+++ b/BottomSheetDemo.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		7DB24C9327BD18F1001030C7 /* BottomSheetUtils.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7DB24C8327BD1813001030C7 /* BottomSheetUtils.framework */; };
 		7DB24CEC27BD1FAD001030C7 /* JMMulticastDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 7DB24CE927BD1FAD001030C7 /* JMMulticastDelegate.m */; };
 		7DD5185028AA2FBA003F3D2A /* UIViewController+Convenience.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DD5184E28AA2F46003F3D2A /* UIViewController+Convenience.swift */; };
+		7DD5185328AA369E003F3D2A /* BottomSheetConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DD5185128AA34D9003F3D2A /* BottomSheetConfiguration.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -111,6 +112,7 @@
 		7DB24C8327BD1813001030C7 /* BottomSheetUtils.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BottomSheetUtils.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7DB24CE927BD1FAD001030C7 /* JMMulticastDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = JMMulticastDelegate.m; sourceTree = "<group>"; };
 		7DD5184E28AA2F46003F3D2A /* UIViewController+Convenience.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Convenience.swift"; sourceTree = "<group>"; };
+		7DD5185128AA34D9003F3D2A /* BottomSheetConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetConfiguration.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -248,6 +250,7 @@
 				7DD5184D28AA2F3B003F3D2A /* Extensions */,
 				7DA6E0B5274F915A009F5C37 /* NavigationController */,
 				7DA6E0B9274F915A009F5C37 /* Presentation */,
+				7DD5185128AA34D9003F3D2A /* BottomSheetConfiguration.swift */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -508,6 +511,7 @@
 				7DA6E0DE274F918E009F5C37 /* BottomSheetModalDismissalHandler.swift in Sources */,
 				7DA6E0DF274F918E009F5C37 /* BottomSheetPresentationController.swift in Sources */,
 				7DA6E0E7274F919A009F5C37 /* UIScrollView+MulticastDelegate.swift in Sources */,
+				7DD5185328AA369E003F3D2A /* BottomSheetConfiguration.swift in Sources */,
 				7DA6E0E8274F919A009F5C37 /* UINavigationController+MulticastDelegate.swift in Sources */,
 				7DA6E0E6274F9196009F5C37 /* CGSize+Helpers.swift in Sources */,
 				7DD5185028AA2FBA003F3D2A /* UIViewController+Convenience.swift in Sources */,

--- a/BottomSheetDemo.xcodeproj/project.pbxproj
+++ b/BottomSheetDemo.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		7DB24C8A27BD1813001030C7 /* BottomSheetUtils.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 7DB24C8327BD1813001030C7 /* BottomSheetUtils.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		7DB24C9327BD18F1001030C7 /* BottomSheetUtils.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7DB24C8327BD1813001030C7 /* BottomSheetUtils.framework */; };
 		7DB24CEC27BD1FAD001030C7 /* JMMulticastDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 7DB24CE927BD1FAD001030C7 /* JMMulticastDelegate.m */; };
+		7DD5185028AA2FBA003F3D2A /* UIViewController+Convenience.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DD5184E28AA2F46003F3D2A /* UIViewController+Convenience.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -109,6 +110,7 @@
 		7DA9B01927439FA100284B0F /* UIControl+EventHandling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIControl+EventHandling.swift"; sourceTree = "<group>"; };
 		7DB24C8327BD1813001030C7 /* BottomSheetUtils.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BottomSheetUtils.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7DB24CE927BD1FAD001030C7 /* JMMulticastDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = JMMulticastDelegate.m; sourceTree = "<group>"; };
+		7DD5184E28AA2F46003F3D2A /* UIViewController+Convenience.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Convenience.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -243,6 +245,7 @@
 			isa = PBXGroup;
 			children = (
 				7DA6E0B4274F915A009F5C37 /* BottomSheetTransitioningDelegate.swift */,
+				7DD5184D28AA2F3B003F3D2A /* Extensions */,
 				7DA6E0B5274F915A009F5C37 /* NavigationController */,
 				7DA6E0B9274F915A009F5C37 /* Presentation */,
 			);
@@ -327,6 +330,14 @@
 			);
 			name = BottomSheetUtils;
 			path = Sources/BottomSheetUtils;
+			sourceTree = "<group>";
+		};
+		7DD5184D28AA2F3B003F3D2A /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				7DD5184E28AA2F46003F3D2A /* UIViewController+Convenience.swift */,
+			);
+			path = Extensions;
 			sourceTree = "<group>";
 		};
 		7DDA237727BD25C800D006FE /* include */ = {
@@ -499,6 +510,7 @@
 				7DA6E0E7274F919A009F5C37 /* UIScrollView+MulticastDelegate.swift in Sources */,
 				7DA6E0E8274F919A009F5C37 /* UINavigationController+MulticastDelegate.swift in Sources */,
 				7DA6E0E6274F9196009F5C37 /* CGSize+Helpers.swift in Sources */,
+				7DD5185028AA2FBA003F3D2A /* UIViewController+Convenience.swift in Sources */,
 				7DA6E0E2274F9196009F5C37 /* UIViewController+Lifecycle.swift in Sources */,
 				7DA6E0DC274F918A009F5C37 /* BottomSheetNavigationStyle.swift in Sources */,
 				7DA6E0DA274F918A009F5C37 /* BottomSheetNavigationController.swift in Sources */,

--- a/BottomSheetDemo/Sources/User Interface/Screens/Resize/ResizeViewController.swift
+++ b/BottomSheetDemo/Sources/User Interface/Screens/Resize/ResizeViewController.swift
@@ -153,9 +153,17 @@ final class ResizeViewController: UIViewController {
     
     private func updateContentHeight(newValue: CGFloat) {
         guard newValue >= 200 && newValue < 5000 else { return }
-        
-        currentHeight = newValue
-        updatePreferredContentSize()
+
+        let updates = { [self] in
+            currentHeight = newValue
+            updatePreferredContentSize()
+        }
+
+        if navigationController == nil {
+            UIView.animate(withDuration: 0.25, animations: updates)
+        } else {
+            updates()
+        }
     }
     
     @objc

--- a/BottomSheetDemo/Sources/User Interface/Screens/Root/RootViewController.swift
+++ b/BottomSheetDemo/Sources/User Interface/Screens/Root/RootViewController.swift
@@ -51,7 +51,9 @@ final class RootViewController: UIViewController {
     @objc
     private func handleShowBottomSheet() {
         let viewController = ResizeViewController(initialHeight: 300)
-        let navigationController = BottomSheetNavigationController(rootViewController: viewController)
-        presentBottomSheet(viewController: navigationController)
+        presentBottomSheetInsideNavigationController(
+            viewController: viewController,
+            configuration: .default
+        )
     }
 }

--- a/BottomSheetDemo/Sources/User Interface/Screens/Root/RootViewController.swift
+++ b/BottomSheetDemo/Sources/User Interface/Screens/Root/RootViewController.swift
@@ -48,37 +48,10 @@ final class RootViewController: UIViewController {
         }
     }
     
-    private var transitionDelegate: UIViewControllerTransitioningDelegate?
-    
     @objc
     private func handleShowBottomSheet() {
         let viewController = ResizeViewController(initialHeight: 300)
         let navigationController = BottomSheetNavigationController(rootViewController: viewController)
-        transitionDelegate = BottomSheetTransitioningDelegate(presentationControllerFactory: self)
-        navigationController.transitioningDelegate = transitionDelegate
-        navigationController.modalPresentationStyle = .custom
-        present(navigationController, animated: true, completion: nil)
-    }
-}
-
-extension RootViewController: BottomSheetPresentationControllerFactory {
-    func makeBottomSheetPresentationController(
-        presentedViewController: UIViewController,
-        presentingViewController: UIViewController?
-    ) -> BottomSheetPresentationController {
-        .init(
-            presentedViewController: presentedViewController,
-            presentingViewController: presentingViewController,
-            dismissalHandler: self
-        )
-    }
-}
-
-extension RootViewController: BottomSheetModalDismissalHandler {
-    var canBeDismissed: Bool { true }
-    
-    func performDismissal(animated: Bool) {
-        presentedViewController?.dismiss(animated: animated, completion: nil)
-        transitionDelegate = nil
+        presentBottomSheet(viewController: navigationController)
     }
 }

--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ Bottom Sheet component is designed to handle any content, including a scrolling 
 - ✅ build flows inside using `BottomSheetNavigationController`
     - ✅ supports all system transitions: push and (interactive) pop
     - ✅ transition animated between different content sizes
+- ✅ Customize appearance:
+    - pull bar visibility
+    - corner radius
+    - shadow background color
 
 ## How it looks like
 
@@ -28,16 +32,36 @@ To integrate Bottom Sheet into your Xcode project using Swift Package Manager, a
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/joomcode/BottomSheet", from: "1.0.0")
+    .package(url: "https://github.com/joomcode/BottomSheet", from: "2.0.0")
 ]
 ```
 
 ## Getting started
 
 This repo contains [demo](https://github.com/joomcode/BottomSheet/tree/main/BottomSheetDemo), which can be a great start for understanding Bottom Sheet usage, but here are simple steps to follow:
-1. Set content's size using [preferredContentSize](https://developer.apple.com/documentation/uikit/uiviewcontroller/1621476-preferredcontentsize)
-2. (optional) Conform to `ScrollableBottomSheetPresentedController` if your view controller is list-based
-3. Present using custom transition `BottomSheetTransitioningDelegate`
+1. Create `UIViewController` to present and set content's size by [preferredContentSize](https://developer.apple.com/documentation/uikit/uiviewcontroller/1621476-preferredcontentsize) property
+2. (optional) Conform to [ScrollableBottomSheetPresentedController](https://github.com/joomcode/BottomSheet/blob/81b0e2a7d405311b8456649452a8c49098490033/Sources/BottomSheet/Core/Presentation/BottomSheetPresentationController.swift#L12-L14) if your view controller is list-based
+3. Present by using [presentBottomSheet(viewController:configuration:)](https://github.com/joomcode/BottomSheet/blob/1870921364ed2cd68d51d7e7837e16e692278ff5/Sources/BottomSheet/Core/Extensions/UIViewController%2BConvenience.swift#L79)
+
+If you want to build flows, use `BottomSheetNavigationController`
+```Swift
+presentBottomSheetInsideNavigationController(
+    viewController: viewControllerToPresent,
+    configuration: .default
+)
+```
+
+You can customize appearance passing configuration parameter
+```Swift
+presentBottomSheet(
+    viewController: viewControllerToPresent,
+    configuration: BottomSheetConfiguration(
+        cornerRadius: 10,
+        pullBarConfiguration: .visible(.init(height: 20)),
+        shadowConfiguration: .init(backgroundColor: UIColor.black.withAlphaComponent(0.6))
+    )
+)
+```
 
 ## Resources
 

--- a/Sources/BottomSheet/Core/BottomSheetConfiguration.swift
+++ b/Sources/BottomSheet/Core/BottomSheetConfiguration.swift
@@ -1,0 +1,56 @@
+//
+//  BottomSheetConfiguration.swift
+//  BottomSheetDemo
+//
+//  Created by Mikhail Maslo on 15.08.2022.
+//  Copyright © 2022 Joom. All rights reserved.
+//
+
+import UIKit
+
+public struct BottomSheetConfiguration {
+    public enum PullBarConfiguration {
+        public struct PullBarAppearance {
+            public let height: CGFloat
+
+            public init(height: CGFloat) {
+                self.height = height
+            }
+        }
+
+        case hidden
+        case visible(PullBarAppearance)
+
+        public static let `default`: PullBarConfiguration = .visible(PullBarAppearance(height: 20))
+    }
+
+    public struct ShadowConfiguration {
+        public let backgroundColor: UIColor
+
+        public init(backgroundColor: UIColor) {
+            self.backgroundColor = backgroundColor
+        }
+
+        public static let `default` = ShadowConfiguration(backgroundColor: UIColor.black.withAlphaComponent(0.6))
+    }
+
+    public let cornerRadius: CGFloat
+    public let pullBarConfiguration: PullBarConfiguration
+    public let shadowConfiguration: ShadowConfiguration
+
+    public init(
+        cornerRadius: CGFloat,
+        pullBarConfiguration: PullBarConfiguration,
+        shadowConfiguration: ShadowConfiguration
+    ) {
+        self.cornerRadius = cornerRadius
+        self.pullBarConfiguration = pullBarConfiguration
+        self.shadowConfiguration = shadowConfiguration
+    }
+
+    public static let `default` = BottomSheetConfiguration(
+        cornerRadius: 10,
+        pullBarConfiguration: .default,
+        shadowConfiguration: .default
+    )
+}

--- a/Sources/BottomSheet/Core/Extensions/UIViewController+Convenience.swift
+++ b/Sources/BottomSheet/Core/Extensions/UIViewController+Convenience.swift
@@ -1,0 +1,91 @@
+//
+//  UIViewController+Convenience.swift
+//  BottomSheetDemo
+//
+//  Created by Mikhail Maslo on 15.08.2022.
+//  Copyright © 2022 Joom. All rights reserved.
+//
+
+import UIKit
+
+public final class DefaultBottomSheetPresentationControllerFactory: BottomSheetPresentationControllerFactory {
+    // MARK: - Nested types
+
+    public typealias DismissalHandlerProvider = () -> BottomSheetModalDismissalHandler
+
+    // MARK: - Public properties
+
+    private let dismissalHandlerProvider: DismissalHandlerProvider
+
+    // MARK: - Init
+
+    public init(dismissalHandlerProvider: @escaping DismissalHandlerProvider) {
+        self.dismissalHandlerProvider = dismissalHandlerProvider
+    }
+
+    // MARK: - BottomSheetPresentationControllerFactory
+
+    public func makeBottomSheetPresentationController(
+        presentedViewController: UIViewController,
+        presentingViewController: UIViewController?
+    ) -> BottomSheetPresentationController {
+        BottomSheetPresentationController(
+            presentedViewController: presentedViewController,
+            presentingViewController: presentingViewController,
+            dismissalHandler: dismissalHandlerProvider()
+        )
+    }
+}
+
+public final class DefaultBottomSheetModalDismissalHandler: BottomSheetModalDismissalHandler {
+    // MARK: - Private properties
+
+    private weak var presentingViewController: UIViewController?
+    private let dismissCompletion: (() -> Void)?
+
+    // MARK: - Init
+
+    init(
+        presentingViewController: UIViewController?,
+        dismissCompletion: (() -> Void)?
+    ) {
+        self.presentingViewController = presentingViewController
+        self.dismissCompletion = dismissCompletion
+    }
+
+    // MARK: - BottomSheetModalDismissalHandler
+
+    public let canBeDismissed: Bool = true
+
+    public func performDismissal(animated: Bool) {
+        presentingViewController?.presentedViewController?.dismiss(animated: animated, completion: dismissCompletion)
+    }
+}
+
+public extension UIViewController {
+    private(set) var bottomSheetTransitionDelegate: UIViewControllerTransitioningDelegate? {
+        get { objc_getAssociatedObject(self, &Self.bottomSheetTransitionDelegateKey) as? UIViewControllerTransitioningDelegate }
+        set { objc_setAssociatedObject(self, &Self.bottomSheetTransitionDelegateKey, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC) }
+    }
+
+    private static var bottomSheetTransitionDelegateKey: UInt8 = 0
+
+    func presentBottomSheet(viewController: UIViewController) {
+        weak var presentingViewController = self
+        weak var currentBottomSheetTransitionDelegate: UIViewControllerTransitioningDelegate?
+        let presentationControllerFactory = DefaultBottomSheetPresentationControllerFactory {
+            DefaultBottomSheetModalDismissalHandler(presentingViewController: presentingViewController) {
+                if currentBottomSheetTransitionDelegate === presentingViewController?.bottomSheetTransitionDelegate {
+                    presentingViewController?.bottomSheetTransitionDelegate = nil
+                }
+            }
+        }
+        bottomSheetTransitionDelegate = BottomSheetTransitioningDelegate(
+            presentationControllerFactory: presentationControllerFactory
+        )
+        currentBottomSheetTransitionDelegate = bottomSheetTransitionDelegate
+        viewController.transitioningDelegate = bottomSheetTransitionDelegate
+        viewController.modalPresentationStyle = .custom
+        present(viewController, animated: true, completion: nil)
+    }
+}

--- a/Sources/BottomSheet/Core/Extensions/UIViewController+Convenience.swift
+++ b/Sources/BottomSheet/Core/Extensions/UIViewController+Convenience.swift
@@ -15,12 +15,17 @@ public final class DefaultBottomSheetPresentationControllerFactory: BottomSheetP
 
     // MARK: - Public properties
 
+    private let configuration: BottomSheetConfiguration
     private let dismissalHandlerProvider: DismissalHandlerProvider
 
     // MARK: - Init
 
-    public init(dismissalHandlerProvider: @escaping DismissalHandlerProvider) {
+    public init(
+        configuration: BottomSheetConfiguration,
+        dismissalHandlerProvider: @escaping DismissalHandlerProvider
+    ) {
         self.dismissalHandlerProvider = dismissalHandlerProvider
+        self.configuration = configuration
     }
 
     // MARK: - BottomSheetPresentationControllerFactory
@@ -32,7 +37,8 @@ public final class DefaultBottomSheetPresentationControllerFactory: BottomSheetP
         BottomSheetPresentationController(
             presentedViewController: presentedViewController,
             presentingViewController: presentingViewController,
-            dismissalHandler: dismissalHandlerProvider()
+            dismissalHandler: dismissalHandlerProvider(),
+            configuration: configuration
         )
     }
 }
@@ -70,10 +76,10 @@ public extension UIViewController {
 
     private static var bottomSheetTransitionDelegateKey: UInt8 = 0
 
-    func presentBottomSheet(viewController: UIViewController) {
+    func presentBottomSheet(viewController: UIViewController, configuration: BottomSheetConfiguration) {
         weak var presentingViewController = self
         weak var currentBottomSheetTransitionDelegate: UIViewControllerTransitioningDelegate?
-        let presentationControllerFactory = DefaultBottomSheetPresentationControllerFactory {
+        let presentationControllerFactory = DefaultBottomSheetPresentationControllerFactory(configuration: configuration) {
             DefaultBottomSheetModalDismissalHandler(presentingViewController: presentingViewController) {
                 if currentBottomSheetTransitionDelegate === presentingViewController?.bottomSheetTransitionDelegate {
                     presentingViewController?.bottomSheetTransitionDelegate = nil
@@ -87,5 +93,10 @@ public extension UIViewController {
         viewController.transitioningDelegate = bottomSheetTransitionDelegate
         viewController.modalPresentationStyle = .custom
         present(viewController, animated: true, completion: nil)
+    }
+
+    func presentBottomSheetInsideNavigationController(viewController: UIViewController, configuration: BottomSheetConfiguration) {
+        let navigationController = BottomSheetNavigationController(rootViewController: viewController, configuration: configuration)
+        presentBottomSheet(viewController: navigationController, configuration: configuration)
     }
 }

--- a/Sources/BottomSheet/Core/NavigationController/BottomSheetNavigationController.swift
+++ b/Sources/BottomSheet/Core/NavigationController/BottomSheetNavigationController.swift
@@ -16,7 +16,20 @@ public final class BottomSheetNavigationController: UINavigationController {
     private var canAnimatePreferredContentSizeUpdates = false
     
     private weak var lastTransitionViewController: UIViewController?
-        
+
+    private let configuration: BottomSheetConfiguration
+
+    // MARK: - Init
+
+    public init(rootViewController: UIViewController, configuration: BottomSheetConfiguration) {
+        self.configuration = configuration
+        super.init(rootViewController: rootViewController)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
     // MARK: - UIViewController
 
     public override func viewDidLoad() {
@@ -128,7 +141,7 @@ extension BottomSheetNavigationController: UINavigationControllerDelegate {
         }
         
         lastTransitionViewController = fromVC
-        return BottomSheetNavigationAnimatedTransitioning(operation: operation)
+        return BottomSheetNavigationAnimatedTransitioning(operation: operation, configuration: configuration)
     }
     
     public func navigationController(

--- a/Sources/BottomSheet/Core/NavigationController/BottomSheetNavigationStyle.swift
+++ b/Sources/BottomSheet/Core/NavigationController/BottomSheetNavigationStyle.swift
@@ -12,11 +12,16 @@ public final class BottomSheetNavigationAnimatedTransitioning: NSObject, UIViewC
     // MARK: - Private
 
     private let operation: UINavigationController.Operation
+    private let configuration: BottomSheetConfiguration
 
     // MARK: - Init
 
-    public init(operation: UINavigationController.Operation) {
+    public init(
+        operation: UINavigationController.Operation,
+        configuration: BottomSheetConfiguration
+    ) {
         self.operation = operation
+        self.configuration = configuration
     }
 
     // MARK: - UIViewControllerAnimatedTransitioning
@@ -78,9 +83,10 @@ public final class BottomSheetNavigationAnimatedTransitioning: NSObject, UIViewC
             height: destinationViewController.preferredContentSize.height + destinationView.safeAreaInsets.top + destinationView.safeAreaInsets.bottom
         )
 
-        let maxHeight = containerViewWindow.bounds.size.height
-            - containerViewWindow.safeAreaInsets.top
-            - BottomSheetPresentationController.pullBarHeight
+        var maxHeight = containerViewWindow.bounds.size.height - containerViewWindow.safeAreaInsets.top
+        if case .visible(let appearance) = configuration.pullBarConfiguration {
+            maxHeight -= appearance.height
+        }
 
         let targetSize = CGSize(
             width: preferredContentSize.width,


### PR DESCRIPTION
- Added convenience methods for presenting BottomSheet
  - `presentBottomSheet(viewController:configuration)`
  - `presentBottomSheetInsideNavigationController(viewController:configuration)`
- Appearance is now configurable and passed through init
- Fixed size changes in Demo project, now they are animated if there is no navigation controller