### PR TITLE
fixed crash on iOS12 and added dismiss handler 

### DIFF
--- a/BottomSheetDemo/Sources/User Interface/Screens/Root/RootViewController.swift
+++ b/BottomSheetDemo/Sources/User Interface/Screens/Root/RootViewController.swift
@@ -54,7 +54,10 @@ final class RootViewController: UIViewController {
         let viewController = ResizeViewController(initialHeight: 300)
         presentBottomSheetInsideNavigationController(
             viewController: viewController,
-            configuration: .default
+            configuration: .default,
+            dismissCompletion: {
+                print("TWA: dismissCompletion")
+            }
         )
     }
 }

--- a/Sources/BottomSheet/Core/Extensions/UIViewController+Convenience.swift
+++ b/Sources/BottomSheet/Core/Extensions/UIViewController+Convenience.swift
@@ -119,4 +119,9 @@ public extension UIViewController {
         let navigationController = BottomSheetNavigationController(rootViewController: viewController, configuration: configuration)
         presentBottomSheet(viewController: navigationController, configuration: configuration)
     }
+
+    func presentBottomSheetInsideNavigationController(viewController: UIViewController, configuration: BottomSheetConfiguration, dismissCompletion: @escaping (() -> Void)) {
+        let navigationController = BottomSheetNavigationController(rootViewController: viewController, configuration: configuration)
+        presentBottomSheet(viewController: navigationController, configuration: configuration, dissmisCompletion: dismissCompletion)
+    }
 }

--- a/Sources/BottomSheet/Core/Extensions/UIViewController+Convenience.swift
+++ b/Sources/BottomSheet/Core/Extensions/UIViewController+Convenience.swift
@@ -95,7 +95,7 @@ public extension UIViewController {
         present(viewController, animated: true, completion: nil)
     }
 
-    func presentBottomSheet(viewController: UIViewController, configuration: BottomSheetConfiguration, @escaping dissmisCompletion: (() -> Void)) {
+    func presentBottomSheet(viewController: UIViewController, configuration: BottomSheetConfiguration, dissmisCompletion: @escaping (() -> Void)) {
         weak var presentingViewController = self
         weak var currentBottomSheetTransitionDelegate: UIViewControllerTransitioningDelegate?
         let presentationControllerFactory = DefaultBottomSheetPresentationControllerFactory(configuration: configuration) {

--- a/Sources/BottomSheet/Core/Extensions/UIViewController+Convenience.swift
+++ b/Sources/BottomSheet/Core/Extensions/UIViewController+Convenience.swift
@@ -95,7 +95,7 @@ public extension UIViewController {
         present(viewController, animated: true, completion: nil)
     }
 
-    func presentBottomSheet(viewController: UIViewController, configuration: BottomSheetConfiguration, dissmisCompletion: (() -> Void)) {
+    func presentBottomSheet(viewController: UIViewController, configuration: BottomSheetConfiguration, @escaping dissmisCompletion: (() -> Void)) {
         weak var presentingViewController = self
         weak var currentBottomSheetTransitionDelegate: UIViewControllerTransitioningDelegate?
         let presentationControllerFactory = DefaultBottomSheetPresentationControllerFactory(configuration: configuration) {

--- a/Sources/BottomSheet/Core/Extensions/UIViewController+Convenience.swift
+++ b/Sources/BottomSheet/Core/Extensions/UIViewController+Convenience.swift
@@ -95,6 +95,26 @@ public extension UIViewController {
         present(viewController, animated: true, completion: nil)
     }
 
+    func presentBottomSheet(viewController: UIViewController, configuration: BottomSheetConfiguration, dissmisCompletion: (() -> Void)) {
+        weak var presentingViewController = self
+        weak var currentBottomSheetTransitionDelegate: UIViewControllerTransitioningDelegate?
+        let presentationControllerFactory = DefaultBottomSheetPresentationControllerFactory(configuration: configuration) {
+            DefaultBottomSheetModalDismissalHandler(presentingViewController: presentingViewController) {
+                if currentBottomSheetTransitionDelegate === presentingViewController?.bottomSheetTransitionDelegate {
+                    presentingViewController?.bottomSheetTransitionDelegate = nil
+                }
+                dissmisCompletion()
+            }
+        }
+        bottomSheetTransitionDelegate = BottomSheetTransitioningDelegate(
+            presentationControllerFactory: presentationControllerFactory
+        )
+        currentBottomSheetTransitionDelegate = bottomSheetTransitionDelegate
+        viewController.transitioningDelegate = bottomSheetTransitionDelegate
+        viewController.modalPresentationStyle = .custom
+        present(viewController, animated: true, completion: nil)
+    }
+
     func presentBottomSheetInsideNavigationController(viewController: UIViewController, configuration: BottomSheetConfiguration) {
         let navigationController = BottomSheetNavigationController(rootViewController: viewController, configuration: configuration)
         presentBottomSheet(viewController: navigationController, configuration: configuration)

--- a/Sources/BottomSheet/Core/NavigationController/BottomSheetNavigationController.swift
+++ b/Sources/BottomSheet/Core/NavigationController/BottomSheetNavigationController.swift
@@ -26,6 +26,10 @@ public final class BottomSheetNavigationController: UINavigationController {
         super.init(rootViewController: rootViewController)
     }
 
+    override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
+        super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
+    }
+
     @available(*, unavailable)
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")

--- a/Sources/BottomSheet/Core/NavigationController/BottomSheetNavigationController.swift
+++ b/Sources/BottomSheet/Core/NavigationController/BottomSheetNavigationController.swift
@@ -27,6 +27,7 @@ public final class BottomSheetNavigationController: UINavigationController {
     }
 
     override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
+        self.configuration = .default
         super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
     }
 


### PR DESCRIPTION
Fix crash on iOS 12 by providing missing initializer in navigation controller - https://github.com/joomcode/BottomSheet/issues/18
Additionally, provide dismiss handler