### PR TITLE
Fix view controller which’s being dismissed

### DIFF
--- a/Sources/BottomSheet/Core/Extensions/UIViewController+Convenience.swift
+++ b/Sources/BottomSheet/Core/Extensions/UIViewController+Convenience.swift
@@ -69,7 +69,7 @@ public final class DefaultBottomSheetModalDismissalHandler: BottomSheetModalDism
     }
 
     public func performDismissal(animated: Bool) {
-        if let presentedViewController = presentingViewController {
+        if let presentedViewController = presentingViewController?.presentedViewController {
             presentedViewController.dismiss(animated: animated, completion: dismissCompletion)
         } else {
             // User dismissed view controller by swipe-gesture, dismiss handler wasn't invoked

--- a/Sources/BottomSheet/Core/Presentation/BottomSheetPresentationController.swift
+++ b/Sources/BottomSheet/Core/Presentation/BottomSheetPresentationController.swift
@@ -192,7 +192,7 @@ public final class BottomSheetPresentationController: UIPresentationController {
     private func startInteractiveTransition() {
         interactionController = UIPercentDrivenInteractiveTransition()
 
-        presentingViewController.dismiss(animated: true) { [weak self] in
+        presentedViewController.dismiss(animated: true) { [weak self] in
             guard let self = self else { return }
 
             if self.presentingViewController.presentedViewController !== self.presentedViewController {


### PR DESCRIPTION
As reported by @VGrokhotov in https://github.com/joomcode/BottomSheet/issues/27 bottom sheet dismisses multiple bottom sheets in hierarchy

As it turned out in code BottomSheet dismissed `presentingViewController` instead of `presentedViewController`, strangely enough UIKit worked as expected with 1 presented BottomSheet