### PR TITLE
Invoke dismiss completion when BottomSheet was dismissed programmaticly

### DIFF
--- a/BottomSheetDemo/Sources/User Interface/Screens/Root/RootViewController.swift
+++ b/BottomSheetDemo/Sources/User Interface/Screens/Root/RootViewController.swift
@@ -60,7 +60,7 @@ final class RootViewController: UIViewController {
                 true
             },
             dismissCompletion: {
-                // handle dismiss completion if user closed bottom sheet by a gesture
+                // handle bottom sheet dismissal completion
             }
         )
     }

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ presentBottomSheet(
         true
     },
     dismissCompletion: {
-        // handle dismiss completion if user closed bottom sheet by a gesture
+        // handle bottom sheet dismissal completion
     }
 )
 ```

--- a/Sources/BottomSheet/Core/Extensions/UIViewController+Convenience.swift
+++ b/Sources/BottomSheet/Core/Extensions/UIViewController+Convenience.swift
@@ -50,6 +50,8 @@ public final class DefaultBottomSheetModalDismissalHandler: BottomSheetModalDism
     private let _canBeDismissed: () -> Bool
     private let dismissCompletion: (() -> Void)?
 
+    private var didInvokeDismissal = false
+
     // MARK: - Init
 
     init(
@@ -75,6 +77,14 @@ public final class DefaultBottomSheetModalDismissalHandler: BottomSheetModalDism
             // User dismissed view controller by swipe-gesture, dismiss handler wasn't invoked
             dismissCompletion?()
         }
+
+        didInvokeDismissal = true
+    }
+
+    public func didDismiss() {
+        guard !didInvokeDismissal else { return }
+
+        dismissCompletion?()
     }
 }
 

--- a/Sources/BottomSheet/Core/Extensions/UIViewController+Convenience.swift
+++ b/Sources/BottomSheet/Core/Extensions/UIViewController+Convenience.swift
@@ -81,7 +81,7 @@ public final class DefaultBottomSheetModalDismissalHandler: BottomSheetModalDism
         didInvokeDismissal = true
     }
 
-    public func didDismiss() {
+    public func didEndDismissal() {
         guard !didInvokeDismissal else { return }
 
         dismissCompletion?()

--- a/Sources/BottomSheet/Core/Presentation/BottomSheetModalDismissalHandler.swift
+++ b/Sources/BottomSheet/Core/Presentation/BottomSheetModalDismissalHandler.swift
@@ -10,4 +10,6 @@ public protocol BottomSheetModalDismissalHandler {
     var canBeDismissed: Bool { get }
 
     func performDismissal(animated: Bool)
+
+    func didDismiss()
 }

--- a/Sources/BottomSheet/Core/Presentation/BottomSheetModalDismissalHandler.swift
+++ b/Sources/BottomSheet/Core/Presentation/BottomSheetModalDismissalHandler.swift
@@ -11,5 +11,5 @@ public protocol BottomSheetModalDismissalHandler {
 
     func performDismissal(animated: Bool)
 
-    func didDismiss()
+    func didEndDismissal()
 }

--- a/Sources/BottomSheet/Core/Presentation/BottomSheetPresentationController.swift
+++ b/Sources/BottomSheet/Core/Presentation/BottomSheetPresentationController.swift
@@ -144,7 +144,7 @@ public final class BottomSheetPresentationController: UIPresentationController {
             removeScrollTrackingIfNeeded()
 
             state = .dismissed
-            dismissalHandler.didDismiss()
+            dismissalHandler.didEndDismissal()
         } else {
             state = .presented
         }

--- a/Sources/BottomSheet/Core/Presentation/BottomSheetPresentationController.swift
+++ b/Sources/BottomSheet/Core/Presentation/BottomSheetPresentationController.swift
@@ -144,6 +144,7 @@ public final class BottomSheetPresentationController: UIPresentationController {
             removeScrollTrackingIfNeeded()
 
             state = .dismissed
+            dismissalHandler.didDismiss()
         } else {
             state = .presented
         }


### PR DESCRIPTION
Addresses https://github.com/joomcode/BottomSheet/issues/36

Add "notification" to dismissal handler when dismissal transition ended